### PR TITLE
API endpoint to support returning a list of all supported languages

### DIFF
--- a/cmd/services/cars-api/main.go
+++ b/cmd/services/cars-api/main.go
@@ -106,7 +106,9 @@ func main() {
 
 	r.HandleFunc("/compile", compileHandlers.HandleCompileRequest).Methods("POST")
 	r.HandleFunc("/compile/{id}", compileHandlers.HandleGetCompileResponse).Methods("GET")
-	r.HandleFunc("/templates/{lang}", routing.HandleGetLanguageTemplate).Methods("GET")
+
+	r.HandleFunc("/languages", routing.HandleListLanguagesSupported).Methods("GET")
+	r.HandleFunc("/languages/{lang}/template", routing.HandleGetLanguageTemplate).Methods("GET")
 
 	log.Info().Msg("listening on :8080")
 

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -1,18 +1,17 @@
 Below includes the documentation of the existing API endpoints which are exposed from the project.
 
 - [Compile](#compile)
-    * [Compile Request](#compile-request)
-        + [Request](#request)
-        + [Response](#response)
-        + [stdin data](#stdin-data)
-        + [expected stdout data](#expected-stdout-data)
-    * [Compile Response](#compile-response)
-        + [Response](#response-1)
-        + [Possible Status Values:](#possible-status-values-)
-        + [Possible Test Status Values:](#possible-test-status-values-)
+	* [Compile Request](#compile-request)
+		+ [Request](#request)
+		+ [Response](#response)
+		+ [stdin data](#stdin-data)
+		+ [expected stdout data](#expected-stdout-data)
+	* [Compile Response](#compile-response)
+		+ [Response](#response-1)
+		+ [Possible Status Values:](#possible-status-values-)
+		+ [Possible Test Status Values:](#possible-test-status-values-)
 - [Templates](#templates)
-    * [Language Template](#language-template)
-
+	* [Language Template](#language-template)
 
 # Compile
 
@@ -104,9 +103,42 @@ Example: `GET - /compile/56ea6176-d23f-4561-b937-b16c6a8434ef`
 * TestFailed
 * TestPassed
 
-# Templates
+# Languages & Templates
 
-API endpoints to support the gathering and working with language templates.
+API endpoints to support the gathering and working with language templates and general language information.
+
+## Supported Languages
+
+This endpoint will return a list of languages that can be exposed to the user. This response contains a display name
+for the language that will contain compiler information if important and will also return the code. The code is
+the value sent to the server when requesting to compile and run.
+
+URL: `GET - /languages`
+
+```json
+[
+  {
+	"language_code": "csharp",
+	"display_name": "C# (dotnet6)"
+  },
+  {
+	"language_code": "node",
+	"display_name": "NodeJs (Javascript)"
+  },
+  {
+	"language_code": "python",
+	"display_name": "Python (pypy)"
+  },
+  {
+	"language_code": "rust",
+	"display_name": "Rust (rustc)"
+  },
+  {
+	"language_code": "go",
+	"display_name": "Golang"
+  }
+]
+```
 
 ## Language Template
 
@@ -114,10 +146,10 @@ This endpoint is designed to allow consumers of the platform to serve the user w
 is more important for languages that require selective formatting or a `main` function. An example of these languages
 would be Haskell, C++, and C.
 
-URL: `GET - /templates/{language}`  
+URL: `GET - /languages/{language}/template`  
 Response: A usable template for that language that will run when attempting to compile
 
-Example: `GET - /templates/cpp`
+Example: `GET - /languages/cpp/template`
 
 ```cpp
 #include <iostream>

--- a/internal/routing/templates.go
+++ b/internal/routing/templates.go
@@ -1,7 +1,10 @@
 package routing
 
 import (
+	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -24,4 +27,36 @@ func HandleGetLanguageTemplate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, _ = w.Write([]byte(template))
+}
+
+type supportedLanguages struct {
+	// The language code send during the compile request, this is not the same as
+	// the display name. This is also the code used to get the template.
+	LanguageCode string `json:"language_code"`
+	// The display name the user can be shown and will understand for example
+	// the display name could be C# and the code would be csharp.
+	DisplayName string `json:"display_name"`
+}
+
+func HandleListLanguagesSupported(w http.ResponseWriter, _ *http.Request) {
+	supported := make([]supportedLanguages, 0, len(sandbox.Compilers))
+
+	for langCode, compiler := range sandbox.Compilers {
+		supportedLang := supportedLanguages{
+			LanguageCode: langCode,
+			DisplayName:  compiler.Language,
+		}
+
+		if compiler.Compiler != "" && !strings.EqualFold(compiler.Compiler, langCode) {
+			supportedLang.DisplayName = fmt.Sprintf("%s (%s)", compiler.Language, compiler.Compiler)
+		}
+
+		supported = append(supported, supportedLang)
+	}
+
+	sort.Slice(supported, func(i, j int) bool {
+		return supported[i].DisplayName < supported[j].DisplayName
+	})
+
+	handleJSONResponse(w, supported, http.StatusOK)
 }

--- a/internal/sandbox/compiler.go
+++ b/internal/sandbox/compiler.go
@@ -36,7 +36,7 @@ type LanguageCompiler struct {
 
 var Compilers = map[string]*LanguageCompiler{
 	"python2": {
-		Language:           "python2",
+		Language:           "Python 2 (pypy)",
 		runSteps:           "pypy /input/source.py",
 		Interpreter:        true,
 		VirtualMachineName: "virtual_machine_python2",
@@ -46,7 +46,7 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"python": {
-		Language:           "python",
+		Language:           "Python (pypy)",
 		runSteps:           "pypy /input/source.py",
 		Interpreter:        true,
 		VirtualMachineName: "virtual_machine_python",
@@ -56,7 +56,7 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"node": {
-		Language:           "NodeJs",
+		Language:           "NodeJs (Javascript)",
 		runSteps:           "node /input/source.js",
 		Interpreter:        true,
 		VirtualMachineName: "virtual_machine_node",
@@ -91,7 +91,7 @@ var Compilers = map[string]*LanguageCompiler{
 	},
 	"go": {
 		Compiler: "go",
-		Language: "Go",
+		Language: "Golang",
 		runSteps: "/out",
 		compileSteps: []string{
 			"cp /input/source.go /project/main.go",

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec make lint

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec make lint


### PR DESCRIPTION
# Why?

Currently the consumer would be required to list all the languages manually. This way, new languages or languages being removed will result in all consumers not making any manual changes, they can use this API response to gather all the languages and display this to the user. The database still tracks the language so this will not be a concern.

URL: `GET - /languages`

```json
[
  {
	"language_code": "csharp",
	"display_name": "C# (dotnet6)"
  },
  {
	"language_code": "node",
	"display_name": "NodeJs (Javascript)"
  },
  {
	"language_code": "python",
	"display_name": "Python (pypy)"
  },
  {
	"language_code": "rust",
	"display_name": "Rust (rustc)"
  },
  {
	"language_code": "go",
	"display_name": "Golang"
  }
]
```