### PR TITLE
Include support for Kotlin and Scala

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
     - cron: '26 9 * * 4'
 
@@ -48,11 +45,11 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
@@ -61,7 +58,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/README.md
+++ b/README.md
@@ -42,18 +42,21 @@ untrusted code inside a container with https://gvisor.dev/, tracking execution p
 
 | Language | Version      | Url                          |
 |----------|--------------|------------------------------|
-| Python2  | v2.7         | https://pypy.org             |
-| Python3  | v3.9         | https://pypy.org             |
-| NodeJs   | v16          | https://nodejs.org           |
-| Rust     | v1.61        | https://rust-lang.org        |
-| Ruby     | v3.1         | https://ruby-lang.org        |
-| Go       | v1.18        | https://go.dev               |
-| Haskell  | v9           | https://haskell.org          |
+| Python2  | 2.7.x        | https://pypy.org             |
+| Python3  | 3.9.x        | https://pypy.org             |
+| NodeJs   | 16.x.x       | https://nodejs.org           |
+| Rust     | 1.61.x       | https://rust-lang.org        |
+| Ruby     | 3.1.x        | https://ruby-lang.org        |
+| Go       | 1.18.x       | https://go.dev               |
+| Haskell  | 9.x.x        | https://haskell.org          |
 | C        | GCC V12      | https://gcc.gnu.org          |
 | C++      | GCC V12      | https://gcc.gnu.org          |
 | C#       | .NET 6.0     | https://dotnet.microsoft.com |
 | F#       | .NET 6.0     | https://dotnet.microsoft.com |
 | Java     | OpenJDK 18.0 | https://openjdk.java.net     |
+| Scala    | 3.1.2        | https://www.scala-lang.org/  |
+| Kotlin   | 1.7.0        | https://kotlinlang.org/      |
+|
 
 ## gVisor (https://gvisor.dev/)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ untrusted code inside a container with https://gvisor.dev/, tracking execution p
 | Java     | OpenJDK 18.0 | https://openjdk.java.net     |
 | Scala    | 3.1.2        | https://www.scala-lang.org/  |
 | Kotlin   | 1.7.0        | https://kotlinlang.org/      |
-|
 
 ## gVisor (https://gvisor.dev/)
 

--- a/build/dockerfiles/openjdk.dockerfile
+++ b/build/dockerfiles/openjdk.dockerfile
@@ -10,7 +10,22 @@ COPY . .
 
 RUN go build -o /runner ./cmd/services/cars-runner/main.go
 
-FROM openjdk:18-alpine
+FROM openjdk:18-buster
+
+RUN apt-get -y update
+
+
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+RUN apt-get -qq -y install curl unzip zip coreutils
+
+#SHELL ["/bin/bash", "-c"]
+
+# Scala
+RUN curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > /cs
+RUN chmod +x /cs
+RUN /cs setup -y
+
+RUN cs install scala:3.1.2 && cs install scalac:3.1.2
 
 COPY --from=BUILDER /runner /runner
-RUN apk --update add coreutils

--- a/build/dockerfiles/openjdk.dockerfile
+++ b/build/dockerfiles/openjdk.dockerfile
@@ -12,21 +12,27 @@ RUN go build -o /runner ./cmd/services/cars-runner/main.go
 
 FROM openjdk:18-buster
 
-RUN apt-get -y update
+ARG SCALA_VERSION="3.1.2"
+ARG KOTLIN_VERSION="1.7.0"
 
+# Installing basic packages
+RUN apt-get update && \
+	apt-get install -y zip unzip curl && \
+	rm -rf /var/lib/apt/lists/* && \
+	rm -rf /tmp/*
 
+# Downloading SDKMAN!
+RUN curl -s "https://get.sdkman.io" | bash
 
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-RUN apt-get -qq -y install curl unzip zip coreutils
-
-# Scala
-RUN curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > /cs
-RUN chmod +x /cs
-RUN /cs setup -y
-
-RUN /cs install scala:3.1.2 && /cs install scalac:3.1.2
-
-RUN mv /root/.local/share/coursier/bin/scala /scala
-RUN mv /root/.local/share/coursier/bin/scalac /scalac
+# Installing Java and Maven, removing some unnecessary SDKMAN files
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install scala $SCALA_VERSION && \
+    yes | sdk install kotlin $KOTLIN_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/* && \
+    ln -s /root/.sdkman/candidates/scala/current/bin/scala /scala && \
+    ln -s /root/.sdkman/candidates/scala/current/bin/scalac /scalac && \
+    ln -s /root/.sdkman/candidates/kotlin/current/bin/kotlin /kotlin && \
+    ln -s /root/.sdkman/candidates/kotlin/current/bin/kotlinc /kotlinc"
 
 COPY --from=BUILDER /runner /runner

--- a/build/dockerfiles/openjdk.dockerfile
+++ b/build/dockerfiles/openjdk.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as BUILDER
+FROM golang:1.18 as BUILDER
 
 WORKDIR /app
 
@@ -19,13 +19,14 @@ RUN apt-get -y update
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN apt-get -qq -y install curl unzip zip coreutils
 
-#SHELL ["/bin/bash", "-c"]
-
 # Scala
 RUN curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > /cs
 RUN chmod +x /cs
 RUN /cs setup -y
 
-RUN cs install scala:3.1.2 && cs install scalac:3.1.2
+RUN /cs install scala:3.1.2 && /cs install scalac:3.1.2
+
+RUN mv /root/.local/share/coursier/bin/scala /scala
+RUN mv /root/.local/share/coursier/bin/scalac /scalac
 
 COPY --from=BUILDER /runner /runner

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -12,7 +12,7 @@ import (
 )
 
 type CompileRequest struct {
-	Language   string `json:"language" validate:"required,oneof=python2 python node rust ruby go haskell c cpp fsharp csharp java"`
+	Language   string `json:"language" validate:"required,oneof=python2 python node rust ruby go haskell c cpp fsharp csharp java kotlin scala"`
 	SourceCode string `json:"source_code" validate:"required"`
 
 	StdinData          []string `json:"stdin_data" validate:"required"`

--- a/internal/sandbox/compiler.go
+++ b/internal/sandbox/compiler.go
@@ -211,7 +211,7 @@ var Compilers = map[string]*LanguageCompiler{
 	"kotlin": {
 		Compiler: "openjdk",
 		Language: "Kotlin",
-		runSteps: "java -jar solution.jar",
+		runSteps: "java -jar /solution.jar",
 		compileSteps: []string{
 			"/kotlinc solution.kt -include-runtime -d /solution.jar",
 		},

--- a/internal/sandbox/compiler.go
+++ b/internal/sandbox/compiler.go
@@ -194,6 +194,20 @@ var Compilers = map[string]*LanguageCompiler{
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
+	"scala": {
+		Compiler: "openjdk",
+		Language: "Scala",
+		runSteps: "bash -c \"scala -cp . Solution\"",
+		compileSteps: []string{
+			"bash -c \"scalac /input/Solution.scala\"",
+		},
+		Interpreter:        false,
+		VirtualMachineName: "virtual_machine_openjdk",
+		SourceFile:         "Solution.scala",
+		OutputFile:         "output",
+		CompilerOutputFile: "compile",
+		InputFile:          "input",
+	},
 }
 
 //go:embed templates/*

--- a/internal/sandbox/compiler.go
+++ b/internal/sandbox/compiler.go
@@ -197,9 +197,9 @@ var Compilers = map[string]*LanguageCompiler{
 	"scala": {
 		Compiler: "openjdk",
 		Language: "Scala",
-		runSteps: "bash -c \"scala -cp . Solution\"",
+		runSteps: "/scala -cp . Solution",
 		compileSteps: []string{
-			"bash -c \"scalac /input/Solution.scala\"",
+			"/scalac /input/Solution.scala",
 		},
 		Interpreter:        false,
 		VirtualMachineName: "virtual_machine_openjdk",

--- a/internal/sandbox/compiler.go
+++ b/internal/sandbox/compiler.go
@@ -208,6 +208,20 @@ var Compilers = map[string]*LanguageCompiler{
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
+	"kotlin": {
+		Compiler: "openjdk",
+		Language: "Kotlin",
+		runSteps: "java -jar solution.jar",
+		compileSteps: []string{
+			"/kotlinc solution.kt -include-runtime -d /solution.jar",
+		},
+		Interpreter:        false,
+		VirtualMachineName: "virtual_machine_openjdk",
+		SourceFile:         "solution.kt",
+		OutputFile:         "output",
+		CompilerOutputFile: "compile",
+		InputFile:          "input",
+	},
 }
 
 //go:embed templates/*

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -310,7 +310,7 @@ func (d *Container) execute(ctx context.Context) error {
 		},
 		nil,
 		nil,
-		"",
+		d.request.ID,
 	)
 
 	if err != nil {

--- a/internal/sandbox/templates/kotlin.txt
+++ b/internal/sandbox/templates/kotlin.txt
@@ -1,0 +1,3 @@
+fun main(args : Array<String>) {
+    println("Hello, World!")
+}

--- a/internal/sandbox/templates/scala.txt
+++ b/internal/sandbox/templates/scala.txt
@@ -1,0 +1,5 @@
+object Solution {
+    def main(args: Array[String]) = {
+        println("Hello, world")
+    }
+}


### PR DESCRIPTION
# Why ? 

This includes support for executing code for Kotlin and Scala at the current latest released versions. This ensures Kotlin, Scala and java all come within the java open-sdk dockerfile. Additionally this changes the sandbox id to the request id for debugging reasons. 