### PR TITLE
Track execution memory consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,33 @@ untrusted code inside a container with https://gvisor.dev/, tracking execution p
 
 | Language | Version      | Url                          |
 |----------|--------------|------------------------------|
-| Python2  | 2.7.x        | https://pypy.org             |
-| Python3  | 3.9.x        | https://pypy.org             |
-| NodeJs   | 16.x.x       | https://nodejs.org           |
-| Rust     | 1.61.x       | https://rust-lang.org        |
-| Ruby     | 3.1.x        | https://ruby-lang.org        |
 | Go       | 1.18.x       | https://go.dev               |
-| Haskell  | 9.x.x        | https://haskell.org          |
-| C        | GCC V12      | https://gcc.gnu.org          |
-| C++      | GCC V12      | https://gcc.gnu.org          |
-| C#       | .NET 6.0     | https://dotnet.microsoft.com |
-| F#       | .NET 6.0     | https://dotnet.microsoft.com |
-| Java     | OpenJDK 18.0 | https://openjdk.java.net     |
-| Scala    | 3.1.2        | https://www.scala-lang.org/  |
-| Kotlin   | 1.7.0        | https://kotlinlang.org/      |
+
+[//]: # (| Python2  | 2.7.x        | https://pypy.org             |)
+
+[//]: # (| Python3  | 3.9.x        | https://pypy.org             |)
+
+[//]: # (| NodeJs   | 16.x.x       | https://nodejs.org           |)
+
+[//]: # (| Rust     | 1.61.x       | https://rust-lang.org        |)
+
+[//]: # (| Ruby     | 3.1.x        | https://ruby-lang.org        |)
+
+[//]: # (| Haskell  | 9.x.x        | https://haskell.org          |)
+
+[//]: # (| C        | GCC V12      | https://gcc.gnu.org          |)
+
+[//]: # (| C++      | GCC V12      | https://gcc.gnu.org          |)
+
+[//]: # (| C#       | .NET 6.0     | https://dotnet.microsoft.com |)
+
+[//]: # (| F#       | .NET 6.0     | https://dotnet.microsoft.com |)
+
+[//]: # (| Java     | OpenJDK 18.0 | https://openjdk.java.net     |)
+
+[//]: # (| Scala    | 3.1.2        | https://www.scala-lang.org/  |)
+
+[//]: # (| Kotlin   | 1.7.0        | https://kotlinlang.org/      |)
 
 ## gVisor (https://gvisor.dev/)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ untrusted code inside a container with https://gvisor.dev/, tracking execution p
 | Kotlin   | 1.7.0        | https://kotlinlang.org/      | ✔️   | ❌      |
 | NodeJs   | 16.x.x       | https://nodejs.org           | ✔️   | ❌      |
 | Python2  | 2.7.x        | https://pypy.org             | ✔️   | ❌      |
-| Python3  | 3.9.x        | https://pypy.org             | ✔️   | ❌      |
+| Python3  | 3.9.x        | https://pypy.org             | ✔️   | ✔️     |
 | Ruby     | 3.1.x        | https://ruby-lang.org        | ✔️   | ❌      |
 | Rust     | 1.61.x       | https://rust-lang.org        | ✔️   | ❌      |
 | Scala    | 3.1.2        | https://www.scala-lang.org/  | ✔️   | ❌      |

--- a/README.md
+++ b/README.md
@@ -42,35 +42,22 @@ untrusted code inside a container with https://gvisor.dev/, tracking execution p
 
 ## Supported Programming Languages
 
-| Language | Version      | Url                          |
-|----------|--------------|------------------------------|
-| Go       | 1.18.x       | https://go.dev               |
-
-[//]: # (| Python2  | 2.7.x        | https://pypy.org             |)
-
-[//]: # (| Python3  | 3.9.x        | https://pypy.org             |)
-
-[//]: # (| NodeJs   | 16.x.x       | https://nodejs.org           |)
-
-[//]: # (| Rust     | 1.61.x       | https://rust-lang.org        |)
-
-[//]: # (| Ruby     | 3.1.x        | https://ruby-lang.org        |)
-
-[//]: # (| Haskell  | 9.x.x        | https://haskell.org          |)
-
-[//]: # (| C        | GCC V12      | https://gcc.gnu.org          |)
-
-[//]: # (| C++      | GCC V12      | https://gcc.gnu.org          |)
-
-[//]: # (| C#       | .NET 6.0     | https://dotnet.microsoft.com |)
-
-[//]: # (| F#       | .NET 6.0     | https://dotnet.microsoft.com |)
-
-[//]: # (| Java     | OpenJDK 18.0 | https://openjdk.java.net     |)
-
-[//]: # (| Scala    | 3.1.2        | https://www.scala-lang.org/  |)
-
-[//]: # (| Kotlin   | 1.7.0        | https://kotlinlang.org/      |)
+| Language | Version      | Url                          | Time | Memory | 
+|----------|--------------|------------------------------|------|--------|
+| C        | GCC V12      | https://gcc.gnu.org          | ✔️   | ❌      |
+| C#       | .NET 6.0     | https://dotnet.microsoft.com | ✔️   | ❌      |
+| C++      | GCC V12      | https://gcc.gnu.org          | ✔️   | ❌      |
+| F#       | .NET 6.0     | https://dotnet.microsoft.com | ✔️   | ❌      |
+| Go       | 1.18.x       | https://go.dev               | ✔️   | ✔️     |
+| Haskell  | 9.x.x        | https://haskell.org          | ✔️   | ❌      |
+| Java     | OpenJDK 18.0 | https://openjdk.java.net     | ✔️   | ❌      |
+| Kotlin   | 1.7.0        | https://kotlinlang.org/      | ✔️   | ❌      |
+| NodeJs   | 16.x.x       | https://nodejs.org           | ✔️   | ❌      |
+| Python2  | 2.7.x        | https://pypy.org             | ✔️   | ❌      |
+| Python3  | 3.9.x        | https://pypy.org             | ✔️   | ❌      |
+| Ruby     | 3.1.x        | https://ruby-lang.org        | ✔️   | ❌      |
+| Rust     | 1.61.x       | https://rust-lang.org        | ✔️   | ❌      |
+| Scala    | 3.1.2        | https://www.scala-lang.org/  | ✔️   | ❌      |
 
 ## gVisor (https://gvisor.dev/)
 

--- a/assets/sample-site/index.html
+++ b/assets/sample-site/index.html
@@ -38,6 +38,9 @@
                         <div class="metric">Code Runtime (Ms):
                             <div id="code-runtime"></div>
                         </div>
+                        <div class="metric">Memory Runtime (MB):
+                            <div id="code-memory-runtime"></div>
+                        </div>
                     </div>
                     <h3 class="header">Input Testing</h3>
                     <p style="max-width: 600px; text-align: justify">

--- a/assets/sample-site/index.js
+++ b/assets/sample-site/index.js
@@ -84,7 +84,7 @@ function clearAllOutput() {
 function writeCompileStatusOutputToDisplay(output) {
     console.log(JSON.stringify(output, null, 2))
 
-    let outputContent = output["output"] || ""
+    let outputContent = `${output["output"] || ""}\n----\n${output["output_error"]}`
 
     if (!isFinishingStatus(output.status)) {
         outputContent = `${state.outputDiv.innerText}${output.status}...\n`

--- a/assets/sample-site/index.js
+++ b/assets/sample-site/index.js
@@ -24,6 +24,7 @@ const state = {
 
     languageModes: document.getElementById("language-modes"),
     codeRuntimeMs: document.getElementById("code-runtime"),
+    codeRuntimeMemoryMb: document.getElementById("code-memory-runtime"),
     compilerRuntimeMs: document.getElementById("compiler-runtime"),
     codeStatus: document.getElementById("execution-status"),
     codeTestStatus: document.getElementById("execution-test-status"),
@@ -91,6 +92,7 @@ function writeCompileStatusOutputToDisplay(output) {
 
     state.compilerRuntimeMs.innerText = output["compile_ms"] || "0"
     state.codeRuntimeMs.innerText = output["runtime_ms"] || "0"
+    state.codeRuntimeMemoryMb.innerText = output["runtime_memory_mb"] || "0"
     state.codeStatus.innerText = output.status
     state.codeTestStatus.innerText = output["test_status"]
 

--- a/build/dockerfiles/go.dockerfile
+++ b/build/dockerfiles/go.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as BUILDER
+FROM golang:1.18-buster as BUILDER
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ COPY . .
 
 RUN go build -o /runner ./cmd/services/cars-runner/main.go
 
-FROM golang:1.18-alpine
+FROM golang:1.18-buster
 
 COPY --from=BUILDER /runner /runner
 

--- a/build/dockerfiles/go.dockerfile
+++ b/build/dockerfiles/go.dockerfile
@@ -17,4 +17,5 @@ COPY --from=BUILDER /runner /runner
 RUN mkdir /project
 RUN cd /project && go mod init project
 
-RUN apk --update add coreutils
+RUN apt-get  update
+RUN apt-get install coreutils

--- a/build/dockerfiles/python.dockerfile
+++ b/build/dockerfiles/python.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as BUILDER
+FROM golang:1.18-buster as BUILDER
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ COPY . .
 
 RUN go build -o /runner ./cmd/services/cars-runner/main.go
 
-FROM pypy:3.9-slim
+FROM pypy:3.9-buster
 
 COPY --from=BUILDER /runner /runner
 RUN apt-get install coreutils

--- a/cmd/services/cars-api/main.go
+++ b/cmd/services/cars-api/main.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/rs/zerolog"
-
 	"compile-and-run-sandbox/internal/config"
 	"compile-and-run-sandbox/internal/files"
 	"compile-and-run-sandbox/internal/parser"
@@ -36,8 +34,6 @@ func getTranslator() ut.Translator {
 }
 
 func main() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-
 	log.Info().Msg("starting cars-api")
 	args := parser.ParseDefaultConfigurationArguments()
 

--- a/cmd/services/cars-loader/main.go
+++ b/cmd/services/cars-loader/main.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/rs/zerolog"
-
 	"compile-and-run-sandbox/internal/parser"
 	"compile-and-run-sandbox/internal/repository"
 
@@ -21,8 +19,6 @@ import (
 )
 
 func main() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-
 	log.Info().Msg("starting cars-loader")
 	args := parser.ParseDefaultConfigurationArguments()
 

--- a/cmd/services/cars-runner/main.go
+++ b/cmd/services/cars-runner/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -138,9 +137,6 @@ func runProject(ctx context.Context, params *sandbox.ExecutionParameters) (*RunE
 	_ = cmd.Wait()
 	close(waitNotification)
 
-	execution := cmd.ProcessState.SysUsage().(*syscall.Rusage)
-
-	fmt.Printf("pid: %d - max memory %dmb\n", cmd.ProcessState.Pid(), memory.Memory(execution.Maxrss).Megabytes())
 	fmt.Printf("pid: %d - max memory %dmb\n", cmd.ProcessState.Pid(), maxMemoryConsumption.Megabytes())
 
 	// close the file after writing to allow full reading from the start

--- a/cmd/services/cars-runner/main.go
+++ b/cmd/services/cars-runner/main.go
@@ -290,6 +290,7 @@ func main() {
 		CompileTime:        compileTime,
 		CompilerOutput:     compilerOutput,
 		Output:             runExecution.standardOutput,
+		OutputErr:          runExecution.errorOutput,
 		Runtime:            runExecution.runtimeNano,
 		RuntimeMemoryBytes: runExecution.memoryConsumption.Bytes(),
 		Status:             responseCode,

--- a/cmd/tools/container-builder/main.go
+++ b/cmd/tools/container-builder/main.go
@@ -41,34 +41,26 @@ func main() {
 			log.Fatalf("language '%s' does not exist in supported compilers\n", filterName)
 		}
 
-		if c.Compiler != "" {
-			runDockerCommand(filterName, c.Compiler, verbose)
-		} else {
-			runDockerCommand(filterName, filterName, verbose)
-		}
-
+		runDockerCommand(c, verbose)
 		return
 	}
 
 	completed := map[string]bool{}
 
-	for langRef, c := range sandbox.Compilers {
+	for _, c := range sandbox.Compilers {
 		if _, ok := completed[c.VirtualMachineName]; ok {
 			continue
 		}
 
-		dockerFilePrefix := strings.Split(c.VirtualMachineName, "_")[2]
-		runDockerCommand(langRef, dockerFilePrefix, verbose)
+		runDockerCommand(c, verbose)
 	}
 }
 
-func runDockerCommand(lang string, name string, verbose bool) {
-	fmt.Printf("%sRunning language:%s %s%s%s\n", RED, ENDCOLOR, GREEN, lang, ENDCOLOR)
+func runDockerCommand(compiler *sandbox.LanguageCompiler, verbose bool) {
+	fmt.Printf("%sRunning language:%s %s%s%s\n", RED, ENDCOLOR, GREEN, compiler.Language, ENDCOLOR)
 
-	path := fmt.Sprintf("./build/dockerfiles/%s.dockerfile", name)
-	machineName := fmt.Sprintf("virtual_machine_%s", name)
-
-	cmd := exec.Command("docker", "build", "-f", path, "-t", machineName)
+	path := fmt.Sprintf("./build/dockerfiles/%s.dockerfile", strings.ToLower(compiler.Dockerfile))
+	cmd := exec.Command("docker", "build", "-f", path, "-t", compiler.VirtualMachineName)
 
 	cmd.Stdout = nil
 	cmd.Stderr = os.Stderr
@@ -84,5 +76,5 @@ func runDockerCommand(lang string, name string, verbose bool) {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("%sFinished language:%s %s%s%s\n", RED, ENDCOLOR, GREEN, lang, ENDCOLOR)
+	fmt.Printf("%sFinished language:%s %s%s%s\n", RED, ENDCOLOR, GREEN, compiler.Language, ENDCOLOR)
 }

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -77,6 +77,7 @@ Example: `GET - /compile/56ea6176-d23f-4561-b937-b16c6a8434ef`
   "test_status": "string",
   "compile_ms": 0,
   "runtime_ms": 0,
+  "runtime_memory_mb": 0,
   "language": "string",
   "output": "string"
 }

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -79,7 +79,8 @@ Example: `GET - /compile/56ea6176-d23f-4561-b937-b16c6a8434ef`
   "runtime_ms": 0,
   "runtime_memory_mb": 0,
   "language": "string",
-  "output": "string"
+  "output": "string",
+  "output_error": "string"
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243 // indirect
 	github.com/firefart/nonamedreturns v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fzipp/gocyclo v0.5.1 // indirect
@@ -173,6 +174,7 @@ require (
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.7.1 // indirect
+	github.com/struCoder/pidusage v0.2.1 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/sylvia7788/contextcheck v1.0.4 // indirect
 	github.com/tdakkota/asciicheck v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
-	github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243 // indirect
 	github.com/firefart/nonamedreturns v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fzipp/gocyclo v0.5.1 // indirect
@@ -174,7 +173,6 @@ require (
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.7.1 // indirect
-	github.com/struCoder/pidusage v0.2.1 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/sylvia7788/contextcheck v1.0.4 // indirect
 	github.com/tdakkota/asciicheck v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,8 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243 h1:QMnlBy37k7MuFqwzUQsbsALRyoKQidWlOv5zNUmqj3w=
+github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243/go.mod h1:YjeiQT/MWPDtPKgk/UAVJ9ZvZLSczA9gobU202W8gPY=
 github.com/firefart/nonamedreturns v1.0.1 h1:fSvcq6ZpK/uBAgJEGMvzErlzyM4NELLqqdTofVjVNag=
 github.com/firefart/nonamedreturns v1.0.1/go.mod h1:D3dpIBojGGNh5UfElmwPu73SwDCm+VKhHYqwlNOk2uQ=
 github.com/frankban/quicktest v1.14.2 h1:SPb1KFFmM+ybpEjPUhCCkZOM5xlovT5UbrMvWnXyBns=
@@ -882,6 +884,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/struCoder/pidusage v0.2.1 h1:dFiEgUDkubeIj0XA1NpQ6+8LQmKrLi7NiIQl86E6BoY=
+github.com/struCoder/pidusage v0.2.1/go.mod h1:bewtP2KUA1TBUyza5+/PCpSQ6sc/H6jJbIKAzqW86BA=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylvia7788/contextcheck v1.0.4 h1:MsiVqROAdr0efZc/fOCt0c235qm9XJqHtWwM+2h2B04=

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,6 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243 h1:QMnlBy37k7MuFqwzUQsbsALRyoKQidWlOv5zNUmqj3w=
-github.com/felixge/pidctrl v0.0.0-20160307080219-7b13bcae7243/go.mod h1:YjeiQT/MWPDtPKgk/UAVJ9ZvZLSczA9gobU202W8gPY=
 github.com/firefart/nonamedreturns v1.0.1 h1:fSvcq6ZpK/uBAgJEGMvzErlzyM4NELLqqdTofVjVNag=
 github.com/firefart/nonamedreturns v1.0.1/go.mod h1:D3dpIBojGGNh5UfElmwPu73SwDCm+VKhHYqwlNOk2uQ=
 github.com/frankban/quicktest v1.14.2 h1:SPb1KFFmM+ybpEjPUhCCkZOM5xlovT5UbrMvWnXyBns=
@@ -884,8 +882,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/struCoder/pidusage v0.2.1 h1:dFiEgUDkubeIj0XA1NpQ6+8LQmKrLi7NiIQl86E6BoY=
-github.com/struCoder/pidusage v0.2.1/go.mod h1:bewtP2KUA1TBUyza5+/PCpSQ6sc/H6jJbIKAzqW86BA=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylvia7788/contextcheck v1.0.4 h1:MsiVqROAdr0efZc/fOCt0c235qm9XJqHtWwM+2h2B04=

--- a/internal/files/local.go
+++ b/internal/files/local.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 type LocalFiles struct {
@@ -26,6 +27,12 @@ func newLocalFiles(config *LocalConfig) (LocalFiles, error) {
 }
 
 func (l LocalFiles) WriteFile(file *File) error {
+	log.Debug().
+		Str("id", file.ID).
+		Str("name", file.Name).
+		Str("data", string(file.Data)).
+		Msg("writing file locally")
+
 	folderDirectory := filepath.Join(l.config.LocalRootPath, file.ID)
 	filePath := filepath.Join(folderDirectory, file.Name)
 

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -5,8 +5,8 @@ type Memory int64
 const (
 	Byte     Memory = 1
 	Kilobyte        = 1024 * Byte
-	Megabyte            = 1024 * Kilobyte
-	Gigabyte            = 1024 * Megabyte
+	Megabyte        = 1024 * Kilobyte
+	Gigabyte        = 1024 * Megabyte
 )
 
 func (d Memory) Bytes() int64 { return int64(d) }

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -16,3 +16,11 @@ func (d Memory) Kilobytes() int64 { return int64(d) / int64(Kilobyte) }
 func (d Memory) Megabytes() int64 { return int64(d) / int64(Megabyte) }
 
 func (d Memory) Gigabytes() int64 { return int64(d) / int64(Gigabyte) }
+
+// LimitExceeded is the error returned by the runner if and when the total
+// allocated memory has been exceeded.
+var LimitExceeded error = memoryLimitExceededError{}
+
+type memoryLimitExceededError struct{}
+
+func (memoryLimitExceededError) Error() string { return "memory limit exceeded" }

--- a/internal/pid/pid.go
+++ b/internal/pid/pid.go
@@ -1,10 +1,11 @@
 // Sourced from here: https://github.com/struCoder/pidusage (MIT) with a small
 // refactor to enable requirements of the platform.
+//
+// PROC Reference - https://man7.org/linux/man-pages/man5/proc.5.html
 
 package pid
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -13,7 +14,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
+
+	"github.com/rs/zerolog/log"
 
 	"compile-and-run-sandbox/internal/memory"
 )
@@ -25,29 +27,206 @@ const (
 
 // SysInfo will record cpu and memory data
 type SysInfo struct {
-	CPU    float64
+	CPU    int64
 	Memory memory.Memory
 }
 
-type Statistics struct {
-	uTime  float64
-	sTime  float64
-	cuTime float64
-	csTime float64
-	start  float64
-	rss    float64
-	uptime float64
+type ProcPidState string
+
+const (
+	ProcPidRunning             ProcPidState = "R" // R  Running
+	ProcPidSleeping            ProcPidState = "S" // S  Sleeping in an interruptible wait
+	ProcPidWaiting             ProcPidState = "D" // D  Waiting in uninterruptible disk sleep
+	ProcPidZombie              ProcPidState = "Z" // Z  Zombie
+	ProcPidStopped             ProcPidState = "T" // T  Stopped (on a signal) or (before Linux 2.6.33) trace stopped
+	ProcPidTracing             ProcPidState = "t" // t  Tracing stop (Linux 2.6.33 onward)
+	ProcPidPaging              ProcPidState = "W" // W  Paging (only before Linux 2.6.0)
+	ProcPidDeadLinuxNew        ProcPidState = "X" // X  Dead (from Linux 2.6.0 onward)
+	ProcPidDeadLinux26633To333 ProcPidState = "x" // x  Dead (Linux 2.6.33 to 3.13 only)
+	ProcPidWakeKill            ProcPidState = "K" // K  Wakekill (Linux 2.6.33 to 3.13 only)
+	ProcPidWaking              ProcPidState = "W" // W  Waking (Linux 2.6.33 to 3.13 only)
+	ProcPidPark                ProcPidState = "P" // P  Parked (Linux 3.9 to 3.13 only)
+)
+
+type ProcPidStatistics struct {
+	// The process ID.
+	Pid int64 `json:"pid"`
+	// The filename of the executable, in parentheses. Strings longer than
+	// TASK_COMM_LEN (16) characters (including the terminating null byte) are
+	// silently truncated.  This is visible whether or not the executable is
+	// swapped out.
+	Comm string `json:"comm"`
+	//  One of the following characters, indicating process State
+	State ProcPidState `json:"state"`
+	//  The PID of the parent of this process.
+	Ppid int64 `json:"ppid"`
+	// The process group ID of the process.
+	Pgrp int64 `json:"pgrp"`
+	// The Session ID of the process.
+	Session int64 `json:"session"`
+	// The controlling terminal of the process.  (The minor device number is
+	// contained in the combination of bits 31 to 20 and 7 to 0; the major
+	// device number is in bits 15 to 8.)
+	TtyNr int64 `json:"ttyNr"`
+	// The ID of the foreground process group of the controlling terminal of the
+	// process.
+	Tpgid int64 `json:"tpgid"`
+	// The kernel flags word of the process.  For bit meanings, see the PF_*
+	// defines in the Linux kernel source file include/linux/sched.h.  Details
+	//  depend on the kernel version.
+	//
+	// The format for this field was %lu before Linux 2.6.
+	Flags int64 `json:"flags"`
+	// The number of minor faults the process has made which have not required
+	// loading a memory page from disk.
+	Minflt int64 `json:"minflt"`
+	// The number of minor faults that the process's waited-for children have
+	// made.
+	Cminflt int64 `json:"cminflt"`
+	// The number of major faults the process has made which have required
+	// loading a memory page from disk.
+	Majflt int64 `json:"majflt"`
+	// The number of major faults that the process's waited-for children have
+	// made.
+	Cmajflt int64 `json:"cmajflt"`
+	// Amount of time that this process has been scheduled in user mode,
+	// measured in clock ticks (divide by sysconf(_SC_CLK_TCK)).  This includes
+	// guest time, GuestTime (time spent running a virtual CPU, see below), so
+	// that applications that are not aware of the guest time field do not lose
+	// that time from their calculations.
+	Utime int64 `json:"utime"`
+	// Amount of time that this process has been scheduled in kernel mode,
+	// measured in clock ticks (divide by sysconf(_SC_CLK_TCK)).
+	Stime int64 `json:"stime"`
+	// Amount of time that this process's waited-for children have been
+	// scheduled in user mode, measured in clock ticks (divide by
+	// sysconf(_SC_CLK_TCK)). (See also times(2).)  This includes guest time,
+	// CguestTime (time spent running a virtual CPU, see below).
+	Cutime int64 `json:"cutime"`
+	// Amount of time that this process's waited-for children have been
+	// scheduled in kernel mode, measured in clock ticks (divide by
+	// sysconf(_SC_CLK_TCK)).
+	Cstime int64 `json:"cstime"`
+	// (Explanation for Linux 2.6) For processes running a real-time scheduling
+	// Policy (Policy below; see sched_setscheduler(2)), this is the negated
+	// scheduling Priority, minus one; that is, a number in the range -2 to -100,
+	// corresponding to real-time priorities 1 to 99.  For processes running
+	// under a non-real-time scheduling Policy, this is the raw Nice value
+	// (setpriority(2)) as represented in the kernel.  The kernel stores Nice
+	// values as numbers in the range 0 (high) to 39 (low), corresponding to the
+	// user-visible Nice range of -20 to 19.
+	//
+	// Before Linux 2.6, this was a scaled value based on
+	// the scheduler weighting given to this process.
+	Priority int64 `json:"priority"`
+	// The Nice value (see setpriority(2)), a value in the range 19 (low
+	// priority) to -20 (high priority).
+	Nice int64 `json:"nice"`
+	// Number of threads in this process (since Linux 2.6).  Before kernel 2.6,
+	// this field was hard coded to 0 as a placeholder for an earlier removed
+	// field.
+	NumThreads int64 `json:"numThreads"`
+	// The time in jiffies before the next SIGALRM is sent to the process due to
+	// an interval timer.  Since kernel 2.6.17, this field is no longer
+	// maintained, and is hard coded as 0.
+	Itrealvalue int64 `json:"itrealvalue"`
+	// The time the process started after system boot.  In kernels before Linux
+	// 2.6, this value was expressed in jiffies.  Since Linux 2.6, the value is
+	// expressed in clock ticks (divide by sysconf(_SC_CLK_TCK)).
+	Starttime int64 `json:"starttime"`
+	// Virtual memory size in bytes.
+	Vsize int64 `json:"vsize"`
+	// Resident Set Size: number of pages the process has in real memory.  This
+	// is just the pages which count toward text, data, or stack space.
+	// This does not include pages which have not been demand-loaded in, or
+	// which are swapped out.  This value is inaccurate; see /proc/[pid]/statm
+	// below.
+	Rss int64 `json:"rss"`
+	// Current soft limit in bytes on the rss of the process; see the
+	// description of RLIMIT_RSS in getrlimit(2).
+	Rsslim int64 `json:"rsslim"`
+	// The address above which program text can run.
+	Startcode int64 `json:"startcode"`
+	// The address below which program text can run.
+	Endcode int64 `json:"endcode"`
+	// The address of the start (i.e., bottom) of the stack.
+	Startstack int64 `json:"startstack"`
+	// The current value of ESP (stack pointer), as found in the kernel stack
+	// page for the process.
+	Kstkesp int64 `json:"kstkesp"`
+	// The current EIP (instruction pointer).
+	Kstkeip int64 `json:"kstkeip"`
+	// The bitmap of pending signals, displayed as a decimal number.  Obsolete,
+	// because it does not provide information on real-time signals; use
+	// /proc/[pid]/status instead.
+	Signal int64 `json:"signal"`
+	// The bitmap of Blocked signals, displayed as a decimal number.  Obsolete,
+	// because it does not provide information on real-time signals; use
+	// /proc/[pid]/status instead.
+	Blocked int64 `json:"blocked"`
+	// The bitmap of ignored signals, displayed as a decimal number.  Obsolete,
+	// because it does not provide information on real-time signals; use
+	// /proc/[pid]/status instead.
+	Sigignore int64 `json:"sigignore"`
+	// The bitmap of caught signals, displayed as a decimal number.  Obsolete,
+	// because it does not provide information on real-time signals; use
+	// /proc/[pid]/status instead.
+	Sigcatch int64 `json:"sigcatch"`
+	// This is the "channel" in which the process is waiting.  It is the address
+	// of a location in the kernel where the process is sleeping.  The
+	// corresponding symbolic name can be found in /proc/[pid]/wchan.
+	Wchan int64 `json:"wchan"`
+	// Number of pages swapped (not maintained).
+	Nswap int64 `json:"nswap"`
+	// Cumulative nswap for child processes (not maintained).
+	Cnswap int64 `json:"cnswap"`
+	// Signal to be sent to parent when we die.
+	ExitSignal int64 `json:"exitSignal"`
+	// CPU number last executed on.
+	Processor int64 `json:"processor"`
+	// Real-time scheduling priority, a number in the range 1 to 99 for
+	// processes scheduled under a real- time Policy, or 0, for non-real-time
+	// processes (see sched_setscheduler(2)).
+	RtPriority int64 `json:"rtPriority"`
+	// Scheduling Policy (see sched_setscheduler(2)). Decode using the SCHED_*
+	// constants in linux/sched.h.
+	Policy int64 `json:"policy"`
+	// The format for this field was int64 before Linux Aggregated block I/O
+	// delays, measured in clock ticks (centiseconds).
+	DelayacctBlkioTicks int64 `json:"delayacctBlkioTicks"`
+	// Guest time of the process (time spent running a virtual CPU for a guest
+	// operating system), measured in clock ticks (divide by sysconf(_SC_CLK_TCK)).
+	GuestTime int64 `json:"guestTime"`
+	// Guest time of the process's children, measured in clock ticks (divide
+	// by sysconf(_SC_CLK_TCK)).
+	CguestTime int64 `json:"cguestTime"`
+	// Address above which program initialized and uninitialized (BSS) data are
+	// placed.
+	StartData int64 `json:"startData"`
+	// Address below which program initialized and uninitialized (BSS) data are
+	// placed.
+	EndData int64 `json:"endData"`
+	// Address above which program heap can be expanded with brk(2).
+	StartBrk int64 `json:"startBrk"`
+	// Address above which program command-line arguments (argv) are placed.
+	ArgStart int64 `json:"argStart"`
+	// Address below program command-line arguments (argv) are placed.
+	ArgEnd int64 `json:"argEnd"`
+	// Address above which program environment is placed.
+	EnvStart int64 `json:"envStart"`
+	// Address below which program environment is placed.
+	EnvEnd int64 `json:"envEnd"`
+	// The thread's exit status in the form reported by
+	// waitpid(2).
+	ExitCode int64 `json:"exitCode"`
 }
 
 var platform = runtime.GOOS
 var eol = "\n"
 
 // Linux platform
-var clkTck float64 = 100    // default
-var PageSize float64 = 4096 // default
-
-var history = map[int]Statistics{}
-var historyLock sync.Mutex
+var clkTck int64 = 100    // default
+var PageSize int64 = 4096 // default
 
 var fnMapping = map[string]string{
 	"aix":     statTypePS,
@@ -74,11 +253,13 @@ func init() {
 
 func initProc() {
 	if clkTckStdout, err := exec.Command("getconf", "CLK_TCK").Output(); err == nil {
-		clkTck = parseFloat(formatStdOut(clkTckStdout, 0)[0])
+		log.Debug().Str("CLK_TCK", string(clkTckStdout)).Msg("getconf")
+		clkTck = parseInt64(formatStdOut(clkTckStdout, 0)[0])
 	}
 
 	if pageSizeStdout, err := exec.Command("getconf", "PAGESIZE").Output(); err == nil {
-		PageSize = parseFloat(formatStdOut(pageSizeStdout, 0)[0])
+		log.Debug().Str("PAGESIZE", string(pageSizeStdout)).Msg("getconf")
+		PageSize = parseInt64(formatStdOut(pageSizeStdout, 0)[0])
 	}
 }
 
@@ -87,98 +268,114 @@ func formatStdOut(stdout []byte, splitIndex int) []string {
 	return strings.Fields(infoArr)
 }
 
-func parseFloat(val string) float64 {
-	floatVal, _ := strconv.ParseFloat(val, 64)
-	return floatVal
-}
-
-func statFromPS(pid int) (*SysInfo, error) {
-	args := "-o pcpu,rss -p"
-
-	if platform == "aix" {
-		args = "-o pcpu,rssize -p"
-	}
-
-	stdout, _ := exec.Command("ps", args, strconv.Itoa(pid)).Output()
-	ret := formatStdOut(stdout, 1)
-
-	if len(ret) == 0 {
-		return nil, errors.New(fmt.Sprintf("Can't find process with this PID: %d", pid))
-	}
-
-	return &SysInfo{
-		CPU:    parseFloat(ret[0]),
-		Memory: memory.Memory(parseFloat(ret[1]) * 1024),
-	}, nil
+func parseInt64(val string) int64 {
+	value, _ := strconv.ParseInt(val, 10, 0)
+	return value
 }
 
 func statFromProc(pid int) (*SysInfo, error) {
 	uptimeFileBytes, err := ioutil.ReadFile(path.Join("/proc", "uptime"))
 
 	if err != nil {
+		log.Error().Err(err).Msg("failed to get proc uptime")
 		return nil, err
 	}
 
-	uptime := parseFloat(strings.Split(string(uptimeFileBytes), " ")[0])
+	uptime := parseInt64(strings.Split(string(uptimeFileBytes), " ")[0])
+
+	log.Debug().
+		Int64("uptime", uptime).
+		Msg("uptime")
+
 	procStatFileBytes, err := ioutil.ReadFile(path.Join("/proc", strconv.Itoa(pid), "stat"))
 
 	if err != nil {
 		return nil, err
 	}
 
-	splitAfter := strings.SplitAfter(string(procStatFileBytes), ")")
+	log.Debug().
+		Str("pid", strconv.Itoa(pid)).
+		Str("raw", string(procStatFileBytes)).
+		Msg("pid states")
 
-	if len(splitAfter) <= 1 {
-		return nil, errors.New(fmt.Sprintf("Can't find process with this PID: %d", pid))
+	infos := strings.Split(string(procStatFileBytes), " ")
+
+	pidStatistics := &ProcPidStatistics{
+		Pid:                 parseInt64(infos[0]),
+		Comm:                infos[1],
+		State:               ProcPidState(infos[2]),
+		Ppid:                parseInt64(infos[3]),
+		Pgrp:                parseInt64(infos[4]),
+		Session:             parseInt64(infos[5]),
+		TtyNr:               parseInt64(infos[6]),
+		Tpgid:               parseInt64(infos[7]),
+		Flags:               parseInt64(infos[8]),
+		Minflt:              parseInt64(infos[9]),
+		Cminflt:             parseInt64(infos[10]),
+		Majflt:              parseInt64(infos[11]),
+		Cmajflt:             parseInt64(infos[12]),
+		Utime:               parseInt64(infos[13]),
+		Stime:               parseInt64(infos[14]),
+		Cutime:              parseInt64(infos[15]),
+		Cstime:              parseInt64(infos[16]),
+		Priority:            parseInt64(infos[17]),
+		Nice:                parseInt64(infos[18]),
+		NumThreads:          parseInt64(infos[19]),
+		Itrealvalue:         parseInt64(infos[20]),
+		Starttime:           parseInt64(infos[21]),
+		Vsize:               parseInt64(infos[22]),
+		Rss:                 parseInt64(infos[23]),
+		Rsslim:              parseInt64(infos[24]),
+		Startcode:           parseInt64(infos[25]),
+		Endcode:             parseInt64(infos[26]),
+		Startstack:          parseInt64(infos[27]),
+		Kstkesp:             parseInt64(infos[28]),
+		Kstkeip:             parseInt64(infos[29]),
+		Signal:              parseInt64(infos[30]),
+		Blocked:             parseInt64(infos[31]),
+		Sigignore:           parseInt64(infos[32]),
+		Sigcatch:            parseInt64(infos[33]),
+		Wchan:               parseInt64(infos[34]),
+		Nswap:               parseInt64(infos[35]),
+		Cnswap:              parseInt64(infos[36]),
+		ExitSignal:          parseInt64(infos[37]),
+		Processor:           parseInt64(infos[38]),
+		RtPriority:          parseInt64(infos[39]),
+		Policy:              parseInt64(infos[40]),
+		DelayacctBlkioTicks: parseInt64(infos[41]),
+		GuestTime:           parseInt64(infos[42]),
+		CguestTime:          parseInt64(infos[43]),
+		StartData:           parseInt64(infos[44]),
+		EndData:             parseInt64(infos[45]),
+		StartBrk:            parseInt64(infos[46]),
+		ArgStart:            parseInt64(infos[47]),
+		ArgEnd:              parseInt64(infos[48]),
+		EnvStart:            parseInt64(infos[49]),
+		EnvEnd:              parseInt64(infos[50]),
+		ExitCode:            parseInt64(infos[51]),
 	}
 
-	infos := strings.Split(splitAfter[1], " ")
-	pidStatistics := &Statistics{
-		uTime:  parseFloat(infos[12]),
-		sTime:  parseFloat(infos[13]),
-		cuTime: parseFloat(infos[14]),
-		csTime: parseFloat(infos[15]),
-		start:  parseFloat(infos[20]) / clkTck,
-		rss:    parseFloat(infos[22]),
-		uptime: uptime,
-	}
+	log.Debug().
+		Interface("pid-statistics", pidStatistics).
+		Msg("pid states")
 
-	historyLock.Lock()
-	defer historyLock.Unlock()
+	total := (pidStatistics.Stime + pidStatistics.Utime) / clkTck
+	seconds := pidStatistics.Starttime - uptime
 
-	// keep a history of the current processor time for the given pid so
-	// that the computed value gets more and more accurate.
-	pidHistory := history[pid]
+	seconds = int64(math.Abs(float64(seconds)))
 
-	// use the history value or default back into the float default value
-	// of 0.0.
-	sTime := pidHistory.sTime
-	uTime := pidHistory.uTime
-
-	total := (pidStatistics.sTime - sTime + pidStatistics.uTime - uTime) / clkTck
-	seconds := pidStatistics.start - uptime
-
-	if pidHistory.uptime != 0 {
-		seconds = uptime - pidHistory.uptime
-	}
-
-	seconds = math.Abs(seconds)
 	if seconds == 0 {
 		seconds = 1
 	}
 
-	history[pid] = *pidStatistics
-
 	return &SysInfo{
 		CPU:    (total / seconds) * 100,
-		Memory: memory.Memory(pidStatistics.rss * PageSize),
+		Memory: memory.Memory(pidStatistics.Rss * PageSize),
 	}, nil
 }
 
 func stat(pid int, statType string) (*SysInfo, error) {
 	switch statType {
-	case statTypePS:
-		return statFromPS(pid)
 	case statTypeProc:
 		return statFromProc(pid)
 	default:

--- a/internal/pid/pid.go
+++ b/internal/pid/pid.go
@@ -1,0 +1,192 @@
+// Sourced from here: https://github.com/struCoder/pidusage (MIT) with a small
+// refactor to enable requirements of the platform.
+
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os/exec"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	"compile-and-run-sandbox/internal/memory"
+)
+
+const (
+	statTypePS   = "ps"
+	statTypeProc = "proc"
+)
+
+// SysInfo will record cpu and memory data
+type SysInfo struct {
+	CPU    float64
+	Memory memory.Memory
+}
+
+type Statistics struct {
+	uTime  float64
+	sTime  float64
+	cuTime float64
+	csTime float64
+	start  float64
+	rss    float64
+	uptime float64
+}
+
+var platform = runtime.GOOS
+var eol = "\n"
+
+// Linux platform
+var clkTck float64 = 100    // default
+var PageSize float64 = 4096 // default
+
+var history = map[int]Statistics{}
+var historyLock sync.Mutex
+
+var fnMapping = map[string]string{
+	"aix":     statTypePS,
+	"darwin":  statTypePS,
+	"freebsd": statTypePS,
+	"sunos":   statTypePS,
+
+	"linux":   statTypeProc,
+	"netbsd":  statTypeProc,
+	"openbsd": statTypeProc,
+
+	"windows": "windows",
+}
+
+func init() {
+	if platform == "windows" {
+		eol = "\r\n"
+	}
+
+	if fnMapping[platform] == statTypeProc {
+		initProc()
+	}
+}
+
+func initProc() {
+	if clkTckStdout, err := exec.Command("getconf", "CLK_TCK").Output(); err == nil {
+		clkTck = parseFloat(formatStdOut(clkTckStdout, 0)[0])
+	}
+
+	if pageSizeStdout, err := exec.Command("getconf", "PAGESIZE").Output(); err == nil {
+		PageSize = parseFloat(formatStdOut(pageSizeStdout, 0)[0])
+	}
+}
+
+func formatStdOut(stdout []byte, splitIndex int) []string {
+	infoArr := strings.Split(string(stdout), eol)[splitIndex]
+	return strings.Fields(infoArr)
+}
+
+func parseFloat(val string) float64 {
+	floatVal, _ := strconv.ParseFloat(val, 64)
+	return floatVal
+}
+
+func statFromPS(pid int) (*SysInfo, error) {
+	args := "-o pcpu,rss -p"
+
+	if platform == "aix" {
+		args = "-o pcpu,rssize -p"
+	}
+
+	stdout, _ := exec.Command("ps", args, strconv.Itoa(pid)).Output()
+	ret := formatStdOut(stdout, 1)
+
+	if len(ret) == 0 {
+		return nil, errors.New(fmt.Sprintf("Can't find process with this PID: %d", pid))
+	}
+
+	return &SysInfo{
+		CPU:    parseFloat(ret[0]),
+		Memory: memory.Memory(parseFloat(ret[1]) * 1024),
+	}, nil
+}
+
+func statFromProc(pid int) (*SysInfo, error) {
+	uptimeFileBytes, err := ioutil.ReadFile(path.Join("/proc", "uptime"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	uptime := parseFloat(strings.Split(string(uptimeFileBytes), " ")[0])
+	procStatFileBytes, err := ioutil.ReadFile(path.Join("/proc", strconv.Itoa(pid), "stat"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	splitAfter := strings.SplitAfter(string(procStatFileBytes), ")")
+
+	if len(splitAfter) <= 1 {
+		return nil, errors.New(fmt.Sprintf("Can't find process with this PID: %d", pid))
+	}
+
+	infos := strings.Split(splitAfter[1], " ")
+	pidStatistics := &Statistics{
+		uTime:  parseFloat(infos[12]),
+		sTime:  parseFloat(infos[13]),
+		cuTime: parseFloat(infos[14]),
+		csTime: parseFloat(infos[15]),
+		start:  parseFloat(infos[20]) / clkTck,
+		rss:    parseFloat(infos[22]),
+		uptime: uptime,
+	}
+
+	historyLock.Lock()
+	defer historyLock.Unlock()
+
+	// keep a history of the current processor time for the given pid so
+	// that the computed value gets more and more accurate.
+	pidHistory := history[pid]
+
+	// use the history value or default back into the float default value
+	// of 0.0.
+	sTime := pidHistory.sTime
+	uTime := pidHistory.uTime
+
+	total := (pidStatistics.sTime - sTime + pidStatistics.uTime - uTime) / clkTck
+	seconds := pidStatistics.start - uptime
+
+	if pidHistory.uptime != 0 {
+		seconds = uptime - pidHistory.uptime
+	}
+
+	seconds = math.Abs(seconds)
+	if seconds == 0 {
+		seconds = 1
+	}
+
+	history[pid] = *pidStatistics
+
+	return &SysInfo{
+		CPU:    (total / seconds) * 100,
+		Memory: memory.Memory(pidStatistics.rss * PageSize),
+	}, nil
+}
+
+func stat(pid int, statType string) (*SysInfo, error) {
+	switch statType {
+	case statTypePS:
+		return statFromPS(pid)
+	case statTypeProc:
+		return statFromProc(pid)
+	default:
+		return nil, fmt.Errorf("unsupported OS %s", runtime.GOOS)
+	}
+}
+
+// GetStat will return current system CPU and memory data
+func GetStat(pid int) (*SysInfo, error) {
+	return stat(pid, fnMapping[platform])
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -152,6 +152,10 @@ func handleNewCompileRequest(data []byte, manager *sandbox.ContainerManager, rep
 		ID:   sandboxRequest.ID,
 		Name: compiler.OutputFile,
 		Data: []byte(strings.Join(resp.Output, "\n")),
+	}, {
+		ID:   sandboxRequest.ID,
+		Name: compiler.OutputErrFile,
+		Data: []byte(strings.Join(resp.OutputError, "\n")),
 	}}
 
 	if !sandboxRequest.Compiler.Interpreter {
@@ -160,7 +164,6 @@ func handleNewCompileRequest(data []byte, manager *sandbox.ContainerManager, rep
 			Name: compiler.CompilerOutputFile,
 			Data: []byte(strings.Join(resp.CompilerOutput, "\n")),
 		})
-
 	}
 
 	_ = fileHandler.WriteFiles(uploadFiles...)

--- a/internal/repository/execution.go
+++ b/internal/repository/execution.go
@@ -11,8 +11,9 @@ type Execution struct {
 	Status     string
 	TestStatus string
 
-	CompileMs int64
-	RuntimeMs int64
+	CompileMs       int64
+	RuntimeMs       int64
+	RuntimeMemoryMb int64
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/routing/compile.go
+++ b/internal/routing/compile.go
@@ -142,17 +142,23 @@ func (h CompilerHandlers) HandleGetCompileResponse(w http.ResponseWriter, r *htt
 		RuntimeMs:       execution.RuntimeMs,
 		RuntimeMemoryMb: execution.RuntimeMemoryMb,
 		Output:          "",
+		OutputErr:       "",
 	}
 
 	compiler := sandbox.Compilers[execution.Language]
 
 	if data, outputErr := h.FileHandler.GetFile(parsedIDValue.String(), compiler.OutputFile); outputErr == nil {
-		log.Info().Str("data", string(data)).Msg("data")
+		log.Debug().Str("data", string(data)).Msg("data")
 		resp.Output = string(data)
 	}
 
+	if data, outputErr := h.FileHandler.GetFile(parsedIDValue.String(), compiler.OutputErrFile); outputErr == nil {
+		log.Debug().Str("data", string(data)).Msg("data")
+		resp.OutputErr = string(data)
+	}
+
 	if data, outputErr := h.FileHandler.GetFile(parsedIDValue.String(), compiler.CompilerOutputFile); outputErr == nil {
-		log.Info().Str("data", string(data)).Msg("data")
+		log.Debug().Str("data", string(data)).Msg("data")
 		resp.CompilerOutput = string(data)
 	}
 

--- a/internal/routing/compile.go
+++ b/internal/routing/compile.go
@@ -135,12 +135,13 @@ func (h CompilerHandlers) HandleGetCompileResponse(w http.ResponseWriter, r *htt
 	}
 
 	resp := CompileInfoResponse{
-		Status:     execution.Status,
-		TestStatus: execution.TestStatus,
-		CompileMs:  execution.CompileMs,
-		Language:   execution.Language,
-		RuntimeMs:  execution.RuntimeMs,
-		Output:     "",
+		Status:          execution.Status,
+		TestStatus:      execution.TestStatus,
+		CompileMs:       execution.CompileMs,
+		Language:        execution.Language,
+		RuntimeMs:       execution.RuntimeMs,
+		RuntimeMemoryMb: execution.RuntimeMemoryMb,
+		Output:          "",
 	}
 
 	compiler := sandbox.Compilers[execution.Language]

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -23,9 +23,10 @@ type CompileInfoResponse struct {
 	Status     string `json:"status"`
 	TestStatus string `json:"test_status"`
 
-	CompileMs int64  `json:"compile_ms"`
-	RuntimeMs int64  `json:"runtime_ms"`
-	Language  string `json:"language"`
+	CompileMs       int64  `json:"compile_ms"`
+	RuntimeMs       int64  `json:"runtime_ms"`
+	RuntimeMemoryMb int64  `json:"runtime_memory_mb"`
+	Language        string `json:"language"`
 
 	Output         string `json:"output"`
 	CompilerOutput string `json:"compiler_output,omitempty"`

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -29,6 +29,7 @@ type CompileInfoResponse struct {
 	Language        string `json:"language"`
 
 	Output         string `json:"output"`
+	OutputErr      string `json:"output_error"`
 	CompilerOutput string `json:"compiler_output,omitempty"`
 }
 

--- a/internal/sandbox/compiler.go
+++ b/internal/sandbox/compiler.go
@@ -12,6 +12,8 @@ type LanguageCompiler struct {
 	// of code that is going to be executed by the requesting machine. e.g Python, Node, JavaScript,
 	// C++.
 	Language string
+	// The prefix for the related docker image used for building.
+	Dockerfile string
 	// The name of the compiler.
 	Compiler string
 	// The name of the compiler used in the steps, this is not including the actions which
@@ -36,6 +38,7 @@ type LanguageCompiler struct {
 
 var Compilers = map[string]*LanguageCompiler{
 	"python2": {
+		Dockerfile:         "python2",
 		Language:           "Python 2 (pypy)",
 		runSteps:           "pypy /input/solution.py",
 		Interpreter:        true,
@@ -46,6 +49,7 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"python": {
+		Dockerfile:         "python",
 		Language:           "Python (pypy)",
 		runSteps:           "pypy /input/solution.py",
 		Interpreter:        true,
@@ -56,6 +60,7 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"node": {
+		Dockerfile:         "node",
 		Language:           "NodeJs (Javascript)",
 		runSteps:           "node /input/solution.js",
 		Interpreter:        true,
@@ -66,6 +71,7 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"ruby": {
+		Dockerfile:         "ruby",
 		Language:           "Ruby",
 		runSteps:           "ruby /input/solution.rb",
 		Interpreter:        true,
@@ -76,9 +82,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"rust": {
-		Compiler: "rustc",
-		Language: "Rust",
-		runSteps: "/solution",
+		Dockerfile: "rust",
+		Compiler:   "rustc",
+		Language:   "Rust",
+		runSteps:   "/solution",
 		compileSteps: []string{
 			"rustc -o /solution /input/solution.rs",
 		},
@@ -90,9 +97,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"go": {
-		Compiler: "go",
-		Language: "Golang",
-		runSteps: "/solution",
+		Dockerfile: "go",
+		Compiler:   "go",
+		Language:   "Golang",
+		runSteps:   "/solution",
 		compileSteps: []string{
 			"cp /input/solution.go /project/main.go",
 			"go build -o /solution /project/main.go",
@@ -105,9 +113,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"haskell": {
-		Compiler: "ghc",
-		Language: "Haskell",
-		runSteps: "/solution",
+		Dockerfile: "haskell",
+		Compiler:   "ghc",
+		Language:   "Haskell",
+		runSteps:   "/solution",
 		compileSteps: []string{
 			"ghc -o /solution /input/solution.hs",
 		},
@@ -119,9 +128,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"c": {
-		Compiler: "gcc",
-		Language: "C",
-		runSteps: "/solution",
+		Dockerfile: "gcc",
+		Compiler:   "gcc",
+		Language:   "C",
+		runSteps:   "/solution",
 		compileSteps: []string{
 			"gcc -g -O2 -std=gnu11 -static -o /solution /input/solution.c -lm",
 		},
@@ -133,9 +143,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"cpp": {
-		Compiler: "gcc",
-		Language: "C++",
-		runSteps: "/solution",
+		Dockerfile: "gcc",
+		Compiler:   "gcc",
+		Language:   "C++",
+		runSteps:   "/solution",
 		compileSteps: []string{
 			"g++ -g -O2 -std=gnu++17 -static -lrt -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -o /solution /input/solution.cpp",
 		},
@@ -147,9 +158,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"fsharp": {
-		Compiler: "dotnet6",
-		Language: "F#",
-		runSteps: "/build-output/projectf",
+		Dockerfile: "dotnet6",
+		Compiler:   "dotnet6",
+		Language:   "F#",
+		runSteps:   "/build-output/projectf",
 		compileSteps: []string{
 			"cp /input/solution.fs /projectf/Program.fs",
 			"dotnet build --configuration Release -o /build-output/ /projectf/",
@@ -162,9 +174,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"csharp": {
-		Compiler: "dotnet6",
-		Language: "C#",
-		runSteps: "/build-output/projectc",
+		Dockerfile: "dotnet6",
+		Compiler:   "dotnet6",
+		Language:   "C#",
+		runSteps:   "/build-output/projectc",
 		compileSteps: []string{
 			"cp /input/solution.cs /projectc/Program.cs",
 			"dotnet build --configuration Release -o /build-output/ /projectc/",
@@ -181,9 +194,10 @@ var Compilers = map[string]*LanguageCompiler{
 	// solution class which is required for execution. If they change the Solution class
 	// name the project will fail to compile.
 	"java": {
-		Compiler: "openjdk",
-		Language: "Java",
-		runSteps: "java -cp . Solution",
+		Dockerfile: "openjdk",
+		Compiler:   "openjdk",
+		Language:   "Java",
+		runSteps:   "java -cp . Solution",
 		compileSteps: []string{
 			"javac /input/Solution.java",
 		},
@@ -195,9 +209,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"scala": {
-		Compiler: "openjdk",
-		Language: "Scala",
-		runSteps: "/scala -cp . Solution",
+		Dockerfile: "openjdk",
+		Compiler:   "openjdk",
+		Language:   "Scala",
+		runSteps:   "/scala -cp . Solution",
 		compileSteps: []string{
 			"/scalac /input/Solution.scala",
 		},
@@ -209,9 +224,10 @@ var Compilers = map[string]*LanguageCompiler{
 		InputFile:          "input",
 	},
 	"kotlin": {
-		Compiler: "openjdk",
-		Language: "Kotlin",
-		runSteps: "java -jar /solution.jar",
+		Dockerfile: "openjdk",
+		Compiler:   "openjdk",
+		Language:   "Kotlin",
+		runSteps:   "java -jar /solution.jar",
 		compileSteps: []string{
 			"/kotlinc solution.kt -include-runtime -d /solution.jar",
 		},

--- a/internal/sandbox/compiler.go
+++ b/internal/sandbox/compiler.go
@@ -8,30 +8,38 @@ import (
 )
 
 type LanguageCompiler struct {
-	// The language that the given compilerName is going to be using or not. This can be seen as the kind
-	// of code that is going to be executed by the requesting machine. e.g Python, Node, JavaScript,
-	// C++.
+	// The language that the given compilerName is going to be using or not.
+	// This can be seen as the kind of code that is going to be executed by
+	// the requesting machine. e.g Python, Node, JavaScript, C++.
 	Language string
 	// The prefix for the related docker image used for building.
 	Dockerfile string
 	// The name of the compiler.
 	Compiler string
-	// The name of the compiler used in the steps, this is not including the actions which
-	// are used to perform the compilation and running.
+	// The name of the compiler used in the steps, this is not including the
+	// actions which are used to perform the compilation and running.
 	runSteps string
-	// The steps used to compile the application, these are skipped if interpreter is true.
+	// The steps used to compile the application, these are skipped if
+	// interpreter is true.
 	compileSteps []string
-	// If the given compilerName is an interpreter or not, since based on this action we would need to
-	// create additional steps for compiling to a file if not.
+	// If the given compilerName is an interpreter or not, since based on this
+	// action we would need to create additional steps for compiling to a file
+	// if not.
 	Interpreter bool
-	// This is the name of docker image that will be executed for the given code sample, this will
-	// be the container that will be used for just this language. Most likely virtual_machine_language,
+	// This is the name of docker image that will be executed for the given code
+	// sample, this will be the container that will be used for just this
+	// language. Most likely virtual_machine_language,
 	// e.g. virtual_machine_python.
 	VirtualMachineName string
 	SourceFile         string
-	//  The file in which the given compilerName will be writing too (standard output and error out),
-	//  since this file will be read when the response returned to the user.
-	OutputFile         string
+	// The file in which the given compiler will be writing too (standard
+	// output), since this file will be read when the response returned to the
+	// user.
+	OutputFile string
+	// The file in which the given compiler will be writing too (error output),
+	// since this file will be read when the response returned to the user.
+	OutputErrFile string
+
 	CompilerOutputFile string
 	InputFile          string
 }
@@ -45,6 +53,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_python2",
 		SourceFile:         "solution.py",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -56,6 +65,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_python",
 		SourceFile:         "solution.py",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -67,6 +77,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_node",
 		SourceFile:         "solution.js",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -78,6 +89,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_ruby",
 		SourceFile:         "solution.rb",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -93,6 +105,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_rust",
 		SourceFile:         "solution.rs",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -109,6 +122,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_go",
 		SourceFile:         "solution.go",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -124,6 +138,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_haskell",
 		SourceFile:         "solution.hs",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -139,6 +154,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_gcc",
 		SourceFile:         "solution.c",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -154,6 +170,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_gcc",
 		SourceFile:         "solution.cpp",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -170,6 +187,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_dotnet6",
 		SourceFile:         "solution.fs",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -186,6 +204,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_dotnet6",
 		SourceFile:         "solution.cs",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -205,6 +224,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_openjdk",
 		SourceFile:         "Solution.java",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -220,6 +240,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_openjdk",
 		SourceFile:         "Solution.scala",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},
@@ -235,6 +256,7 @@ var Compilers = map[string]*LanguageCompiler{
 		VirtualMachineName: "virtual_machine_openjdk",
 		SourceFile:         "solution.kt",
 		OutputFile:         "output",
+		OutputErrFile:      "output_error",
 		CompilerOutputFile: "compile",
 		InputFile:          "input",
 	},

--- a/internal/sandbox/profile.go
+++ b/internal/sandbox/profile.go
@@ -36,7 +36,11 @@ type Profile struct {
 	// The maximum amount of memory the container can use. If you set this
 	// option, the minimum allowed value is 6m (6 megabytes). That is, you must
 	// set the value to at least 6 megabytes.
-	Memory memory.Memory
+	ContainerMemory memory.Memory
+	// The maximum amount of memory allowed to be used by the code execution.
+	// Ideally keep the container memory higher to allow the code to fully use
+	// its full range.
+	ExecutionMemory memory.Memory
 	// The amount of memory this container is allowed to swap to disk.
 	MemorySwap memory.Memory
 }
@@ -50,32 +54,36 @@ var _ = map[uint]*Profile{
 // Profiles is a list of all currently supported profiles in the system
 var profiles = map[string]*Profile{
 	"development_linux": {
-		AutoRemove:     true,
-		CodeTimeout:    time.Second * 5,
-		CompileTimeout: time.Second * 20,
-		Memory:         memory.Gigabyte * 10,
-		Runtime:        GVisor,
+		AutoRemove:      true,
+		CodeTimeout:     time.Second * 5,
+		CompileTimeout:  time.Second * 20,
+		ContainerMemory: memory.Gigabyte * 2,
+		ExecutionMemory: memory.Gigabyte,
+		Runtime:         GVisor,
 	},
 	"development_windows": {
-		AutoRemove:     false,
-		CodeTimeout:    time.Second * 5,
-		CompileTimeout: time.Second * 20,
-		Memory:         memory.Gigabyte * 10,
-		Runtime:        Default,
+		AutoRemove:      true,
+		CodeTimeout:     time.Second * 10,
+		CompileTimeout:  time.Second * 20,
+		ContainerMemory: memory.Gigabyte * 2,
+		ExecutionMemory: memory.Gigabyte,
+		Runtime:         Default,
 	},
 	"production": {
-		AutoRemove:     true,
-		CodeTimeout:    time.Second,
-		CompileTimeout: time.Second * 10,
-		Memory:         memory.Gigabyte,
-		Runtime:        GVisor,
+		AutoRemove:      true,
+		CodeTimeout:     time.Second,
+		CompileTimeout:  time.Second * 10,
+		ContainerMemory: memory.Gigabyte * 2,
+		ExecutionMemory: memory.Gigabyte,
+		Runtime:         GVisor,
 	},
 	"staging": {
-		AutoRemove:     true,
-		CodeTimeout:    time.Second * 2,
-		CompileTimeout: time.Second * 20,
-		Memory:         memory.Gigabyte * 2,
-		Runtime:        GVisor,
+		AutoRemove:      true,
+		CodeTimeout:     time.Second * 2,
+		CompileTimeout:  time.Second * 20,
+		ContainerMemory: memory.Gigabyte * 2,
+		ExecutionMemory: memory.Gigabyte,
+		Runtime:         GVisor,
 	},
 }
 

--- a/internal/sandbox/profile.go
+++ b/internal/sandbox/profile.go
@@ -63,7 +63,7 @@ var profiles = map[string]*Profile{
 	},
 	"development_windows": {
 		AutoRemove:      true,
-		CodeTimeout:     time.Second * 10,
+		CodeTimeout:     time.Second * 5,
 		CompileTimeout:  time.Second * 20,
 		ContainerMemory: memory.Gigabyte * 2,
 		ExecutionMemory: memory.Gigabyte,

--- a/internal/sandbox/profile.go
+++ b/internal/sandbox/profile.go
@@ -57,7 +57,7 @@ var profiles = map[string]*Profile{
 		Runtime:        GVisor,
 	},
 	"development_windows": {
-		AutoRemove:     true,
+		AutoRemove:     false,
 		CodeTimeout:    time.Second * 5,
 		CompileTimeout: time.Second * 20,
 		Memory:         memory.Gigabyte * 10,

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -110,6 +110,7 @@ type ExecutionResponse struct {
 	CompileTime        int64           `json:"compileTime"`
 	CompilerOutput     []string        `json:"compilerOutput"`
 	Output             []string        `json:"output"`
+	OutputErr          []string        `json:"output_error"`
 	Runtime            int64           `json:"runTime"`
 	RuntimeMemoryBytes int64           `json:"runtimeMemory"`
 	Status             ContainerStatus `json:"status"`
@@ -119,8 +120,13 @@ type Response struct {
 	// The raw output that was produced by the sandbox compiler running.
 	CompilerOutput []string
 
-	// The raw output that was produced by the sandbox.
+	// The raw output written into the stdout for the sandbox. This has a hard
+	// limit of a given number of characters.
 	Output []string
+
+	// The raw output written into the stderr for the sandbox. This has a hard
+	// limit of a given number of characters.
+	OutputError []string
 
 	// The given status of the sandbox.
 	Status ContainerStatus
@@ -421,6 +427,7 @@ func (d *Container) GetResponse() *Response {
 	return &Response{
 		CompilerOutput: d.executionResponse.CompilerOutput,
 		Output:         d.executionResponse.Output,
+		OutputError:    d.executionResponse.OutputErr,
 		Status:         d.executionResponse.Status,
 		TestStatus:     testStatus,
 		Runtime:        time.Duration(d.executionResponse.Runtime) * time.Nanosecond,


### PR DESCRIPTION
# Why ?

To get more fine control over the ability to limit the execution code we need to be able to limit the amount of memory a given device runs at. We already set hard container limits but this does not stop us killing or tracking the memory used by the device.

This change introduces the implementation requirements to track memory consumption on a Debian docker instance. By doing so on a standard image will allow introducing more languages faster and easier.

The current supported languages for memory tracking is: Python3 and Go