### PR TITLE
feat: java memory tracking (increase heap size)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ untrusted code inside a container with https://gvisor.dev/, tracking execution p
 | Language | Version      | Url                          | Time | Memory |
 |----------|--------------|------------------------------|------|--------|
 | C        | GCC V12      | https://gcc.gnu.org          | ✔️   | ❌      |
-| C#       | .NET 6.0     | https://dotnet.microsoft.com | ✔️   | ✔️      |
 | C++      | GCC V12      | https://gcc.gnu.org          | ✔️   | ❌      |
+| C#       | .NET 6.0     | https://dotnet.microsoft.com | ✔️   | ✔️      |
 | F#       | .NET 6.0     | https://dotnet.microsoft.com | ✔️   | ✔️      |
-| Go       | 1.18.x       | https://go.dev               | ✔️   | ✔️     |
-| Haskell  | 9.x.x        | https://haskell.org          | ✔️   | ❌      |
-| Java     | OpenJDK 18.0 | https://openjdk.java.net     | ✔️   | ❌      |
-| Kotlin   | 1.7.0        | https://kotlinlang.org/      | ✔️   | ❌      |
+| Java     | OpenJDK 18.0 | https://openjdk.java.net     | ✔️   | ✔️     |
+| Kotlin   | 1.7.0        | https://kotlinlang.org/      | ✔️   | ✔️      |
+| Scala    | 3.1.2        | https://www.scala-lang.org/  | ✔️   | ✔️     |
 | NodeJs   | 16.x.x       | https://nodejs.org           | ✔️   | ✔️     |
 | Python2  | 2.7.x        | https://pypy.org             | ✔️   | ✔️     |
 | Python3  | 3.9.x        | https://pypy.org             | ✔️   | ✔️     |
+| Go       | 1.18.x       | https://go.dev               | ✔️   | ✔️     |
+| Haskell  | 9.x.x        | https://haskell.org          | ✔️   | ❌      |
 | Ruby     | 3.1.x        | https://ruby-lang.org        | ✔️   | ✔️      |
 | Rust     | 1.61.x       | https://rust-lang.org        | ✔️   | ❌      |
-| Scala    | 3.1.2        | https://www.scala-lang.org/  | ✔️   | ❌      |
 
 ## gVisor (https://gvisor.dev/)
 

--- a/build/dockerfiles/openjdk.dockerfile
+++ b/build/dockerfiles/openjdk.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as BUILDER
+FROM golang:1.18-buster as BUILDER
 
 WORKDIR /app
 

--- a/internal/sandbox/compiler.go
+++ b/internal/sandbox/compiler.go
@@ -216,7 +216,7 @@ var Compilers = map[string]*LanguageCompiler{
 		Dockerfile: "openjdk",
 		Compiler:   "openjdk",
 		Language:   "Java",
-		runSteps:   "java -cp . Solution",
+		runSteps:   "java -Xmx2048m -cp . Solution",
 		compileSteps: []string{
 			"javac /input/Solution.java",
 		},
@@ -232,7 +232,7 @@ var Compilers = map[string]*LanguageCompiler{
 		Dockerfile: "openjdk",
 		Compiler:   "openjdk",
 		Language:   "Scala",
-		runSteps:   "/scala -cp . Solution",
+		runSteps:   "/scala -J-Xmx2048m -cp . Solution",
 		compileSteps: []string{
 			"/scalac /input/Solution.scala",
 		},
@@ -248,7 +248,7 @@ var Compilers = map[string]*LanguageCompiler{
 		Dockerfile: "openjdk",
 		Compiler:   "openjdk",
 		Language:   "Kotlin",
-		runSteps:   "java -jar /solution.jar",
+		runSteps:   "java -Xmx2048m -jar /solution.jar",
 		compileSteps: []string{
 			"/kotlinc solution.kt -include-runtime -d /solution.jar",
 		},


### PR DESCRIPTION
# Why?

This ensures support for memory tracking for java applications, this also increases the heap allocation for all. The following are now supported and have max heap allocation of 2GB

* Java
* Scala
* Kotlin